### PR TITLE
Fixed: now the database on the website is displaying the database.

### DIFF
--- a/Frontend/src/components/Home.jsx
+++ b/Frontend/src/components/Home.jsx
@@ -13,7 +13,7 @@ const Home = () => {
     tool: [],
     platform: [],
     methodology: [],
-    databases: [],
+    database: [],
     "soft skill": [],
   });
   const [allJobs, setAllJobs] = useState([]);
@@ -72,7 +72,7 @@ const Home = () => {
       tool: [],
       platform: [],
       methodology: [],
-      databases: [],
+      database: [],
       "soft skill": [],
     };
 


### PR DESCRIPTION
**Issue:**
- When loading the local webpage, the "Database" category under the skills chart was not displaying any data.
- This was caused by a mismatch between the backend key (`database`) and the frontend state key (`databases`).

**Fix:**
- Corrected the variable name in `Home.jsx` from `databases` to `database` to match the backend.
- Now the "Database" chart renders correctly when data is available.