### PR TITLE
Fix Skills & Job Chart Display on Staging

### DIFF
--- a/Frontend/src/components/Home.jsx
+++ b/Frontend/src/components/Home.jsx
@@ -120,10 +120,68 @@ const Home = () => {
   }, [filteredJobs]);
 
   useEffect(() => {
-  fetchJobs();
-  fetchSkillsSummary();
-  fetchLocationSummary();
+  // Fetch jobs
+  fetch(`${import.meta.env.VITE_API_URL}/jobs`)
+    .then((res) => res.json())
+    .then((data) => {
+      setAllJobs(data);
+      setFilteredJobs(data);
+    });
+
+  // Fetch skills-summary
+fetch(`${import.meta.env.VITE_API_URL}/skills-summary`)
+  .then((res) => res.json())
+  .then((data) => {
+    const allowedTypes = [
+      "database",
+      "tool",
+      "framework",
+      "programming language",
+      "platform",
+      "methodology",
+      "soft skill",
+      "software",
+      "technology",
+      "networking",
+    ];
+
+    const grouped = {};
+    data.forEach((item) => {
+      const type = item.type?.toLowerCase();
+      if (!allowedTypes.includes(type)) return;
+
+      if (!grouped[type]) grouped[type] = [];
+      grouped[type].push({ skill: item.skill, count: item.count });
+    });
+
+    setSkillsData(grouped);
+    setHasData(Object.keys(grouped).some((type) => grouped[type]?.length > 0));
+  })
+  .catch((err) => {
+    console.error("Error fetching skills summary:", err);
+    setHasData(false);
+  })
+  .finally(() => {
+    setIsLoading(false);
+  });
+
+
+  // Fetch location-summary
+  fetch(`${import.meta.env.VITE_API_URL}/location-summary`)
+    .then((res) => res.json())
+    .then((data) => {
+      const mapped = data.map((item) => ({
+        name: item.location,
+        value: item.count,
+      }));
+      setLocationData(mapped);
+    })
+    .catch((err) => {
+      console.error("Error fetching location summary:", err);
+      setLocationData([]);
+    });
 }, []);
+
 
   useEffect(() => {
     const updated = {};

--- a/Frontend/src/components/JoboverTimeChart.jsx
+++ b/Frontend/src/components/JoboverTimeChart.jsx
@@ -13,8 +13,8 @@ export default function JobsOverTimeChart({ jobs }) {
   const counts = {};
 
   jobs.forEach((job) => {
-    const date = typeof job?.date === "string" ? job.date.slice(0, 10) : null;
-    if (!date) return;
+    if (!job.date) return;
+    const date = job.date.split("T")[0];
     counts[date] = (counts[date] || 0) + 1;
   });
 

--- a/Frontend/src/components/JoboverTimeChart.jsx
+++ b/Frontend/src/components/JoboverTimeChart.jsx
@@ -10,11 +10,11 @@ import {
 } from "recharts";
 
 export default function JobsOverTimeChart({ jobs }) {
-  // Transform raw jobs array into date -> count array
   const counts = {};
+
   jobs.forEach((job) => {
-    if (!job.date) return; // Skip if no date
-    const date = job.date.split("T")[0]; // Only keep YYYY-MM-DD
+    const date = job?.date?.split("T")[0]; // Only keep YYYY-MM-DD
+    if (!date) return;
     counts[date] = (counts[date] || 0) + 1;
   });
 

--- a/Frontend/src/components/JoboverTimeChart.jsx
+++ b/Frontend/src/components/JoboverTimeChart.jsx
@@ -13,7 +13,7 @@ export default function JobsOverTimeChart({ jobs }) {
   const counts = {};
 
   jobs.forEach((job) => {
-    const date = job?.date?.split("T")[0]; // Only keep YYYY-MM-DD
+    const date = typeof job?.date === "string" ? job.date.slice(0, 10) : null;
     if (!date) return;
     counts[date] = (counts[date] || 0) + 1;
   });
@@ -23,23 +23,21 @@ export default function JobsOverTimeChart({ jobs }) {
     .sort((a, b) => new Date(a.date) - new Date(b.date));
 
   return (
-  <>
-  <ResponsiveContainer width="100%" height={300}>
-    <LineChart data={chartData}>
-      <CartesianGrid strokeDasharray="3 3" />
-      <XAxis dataKey="date" minTickGap={30} />
-      <YAxis allowDecimals={false} />
-      <Tooltip />
-      <Line
-        type="monotone"
-        dataKey="count"
-        stroke="#3b82f6"
-        strokeWidth={2}
-      />
-    </LineChart>
-  </ResponsiveContainer>
-</>
-
-);
-
+    <>
+      <ResponsiveContainer width="100%" height={300}>
+        <LineChart data={chartData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="date" minTickGap={30} />
+          <YAxis allowDecimals={false} />
+          <Tooltip />
+          <Line
+            type="monotone"
+            dataKey="count"
+            stroke="#3b82f6"
+            strokeWidth={2}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </>
+  );
 }


### PR DESCRIPTION
## Summary

This PR fixes the issue where:
- "Jobs Posted Over Time" chart appeared empty
- Unwanted skill charts (e.g., random types) were displayed

## Changes Made

### Restored Job Data Fetching
- Re-added direct fetch call to `/jobs` in `Home.jsx`
- Set `allJobs` and `filteredJobs` to restore summary and chart data

### Skills Chart Filtering
- Limited skills displayed to 10 specific types:
  - `database`
  - `tool`
  - `framework`
  - `programming language`
  - `platform`
  - `methodology`
  - `soft skill`
  - `software`
  - `technology`
  - `networking`

### Other Adjustments
- `filteredJobs` correctly passed to `JobsOverTimeChart`
- Removed unnecessary `fetchJobs()` function if not used
- Skills/Location charts now display only if relevant data is loaded
