### PR TITLE
Key states update

### DIFF
--- a/Frontend/src/App.css
+++ b/Frontend/src/App.css
@@ -114,6 +114,7 @@ body {
   background-color: #4b5563;
 }
 
+
 /* Hamburger */
 .hamburger-btn {
   display: none;

--- a/Frontend/src/Navbar.jsx
+++ b/Frontend/src/Navbar.jsx
@@ -43,7 +43,7 @@ const Navbar = ({
     <nav className="navbar">
       <div className="navbar-container">
         <div className="navbar-brand">
-          <span style={{ color: "#3b82f6" }}>IT</span> Monitor
+          <span style={{ color: "#3b82f6" }}>IT</span> Skills Monitor
         </div>
 
         <button

--- a/Frontend/src/components/SummarySection.jsx
+++ b/Frontend/src/components/SummarySection.jsx
@@ -88,27 +88,27 @@ const SummarySection = ({ jobs = [] }) => {
   return (
     <section className="summary-grid">
       <SummaryCard
-        title="Total Jobs"
+        title="Total Available Jobs"
         value={stats.total.toLocaleString()}
         helper="Current dataset"
       />
       <SummaryCard
-        title="Average Salary"
+        title="Average Listed Salary"
         value={stats.avgSalary ? `NZ$ ${stats.avgSalary.toLocaleString()}` : "N/A"}
         helper={stats.avgSalary ? "From available listings" : "No salary data"}
       />
       <SummaryCard
-        title="Most Common Location"
+        title="Top Hiring Location"
         value={stats.location ? titleCase(stats.location.value) : "N/A"}
         helper={stats.location ? `${stats.location.count} listings` : "—"}
       />
       <SummaryCard
-        title="Top Skill"
+        title="Most In-Demand Skills"
         value={stats.topSkill ? titleCase(stats.topSkill.value) : "N/A"}
         helper={stats.topSkill ? `${stats.topSkill.count} mentions` : "—"}
       />
       <SummaryCard
-        title="Top Category"
+        title="Most Listed Category"
         value={stats.category ? titleCase(stats.category.value) : "N/A"}
         helper={stats.category ? `${stats.category.count} listings` : "—"}
       />

--- a/Frontend/src/components/SummarySection.jsx
+++ b/Frontend/src/components/SummarySection.jsx
@@ -65,11 +65,36 @@ const titleCase = (s) => (s ? s.replace(/\b\w/g, (c) => c.toUpperCase()) : s);
 // ----- component -----
 const SummarySection = ({ jobs = [] }) => {
   const stats = useMemo(() => {
-    const total = jobs.length;
+    if (!jobs.length) return {};
+    // Normalize scrape dates
+const toDay = (v) => {
+  if (!v) return null;
+  const d = new Date(v);
+  if (isNaN(d)) return null;
+  return d.toISOString().slice(0, 10); // YYYY-MM-DD
+};
+
+const pickDate = (j) =>
+  j.scrapeDate ?? j.scrape_date ?? j.scraped_at ?? j.scrapedAt ?? j.created_at ?? j.date;
+
+// Group jobs by scrape day
+const scrapeMap = {};
+for (const job of jobs) {
+  const key = toDay(pickDate(job));
+  if (!key) continue;
+  if (!scrapeMap[key]) scrapeMap[key] = [];
+  scrapeMap[key].push(job);
+}
+
+// Get most recent scrape batch
+const latestDate = Object.keys(scrapeMap).sort().pop();
+const latestJobs = scrapeMap[latestDate] || [];
+
+  
 
     // Average salary
     const salaries = [];
-    for (const j of jobs) {
+    for (const j of latestJobs) {
       const v = pickSalary(j);
       if (Number.isFinite(v)) salaries.push(v);
     }
@@ -78,9 +103,12 @@ const SummarySection = ({ jobs = [] }) => {
       : null;
 
     // Other key stats
-    const location = mostCommon(jobs.map((j) => j.location));
-    const category = mostCommon(jobs.map((j) => j.category));
-    const topSkill = topSkillFromJobs(jobs);
+    const location = mostCommon(latestJobs.map((j) => j.location));
+    const category = mostCommon(latestJobs.map((j) => j.category));
+    const topSkill = topSkillFromJobs(latestJobs);
+    const total = latestJobs.length;
+
+    
 
     return { total, avgSalary, location, category, topSkill };
   }, [jobs]);

--- a/Frontend/src/components/SummarySection.jsx
+++ b/Frontend/src/components/SummarySection.jsx
@@ -117,7 +117,7 @@ const latestJobs = scrapeMap[latestDate] || [];
     <section className="summary-grid">
       <SummaryCard
         title="Total Available Jobs"
-        value={stats.total.toLocaleString()}
+        value={stats.total ? stats.total.toLocaleString() : "N/A"}
         helper="Current dataset"
       />
       <SummaryCard


### PR DESCRIPTION
## Summary
This pull request enhances the accuracy and clarity of the dashboard’s summary statistics while improving brand consistency.

## Changes Included
- Updated **navbar brand name** to reflect standard naming across the site
- Renamed summary metric cards for clarity (e.g., “Total Available Jobs”, “Top Hiring Location”)
- Modified logic to calculate summary metrics **only from the latest completed scrape**, instead of cumulative data

## Why This Matters
This ensures that users are always presented with up-to-date, relevant insights based on the most recent scraping session. It improves data integrity and aligns the dashboard’s information with expected monthly scrape cycles.


before:
<img width="1903" height="270" alt="image" src="https://github.com/user-attachments/assets/a639a216-6d34-496a-a09b-df5c324e77cb" />

after:
<img width="1892" height="334" alt="{121CFB0A-F230-4BCE-962E-18D580E97E76}" src="https://github.com/user-attachments/assets/258ce2fa-16b1-410b-a0dd-21406d5d5a8d" />
