### PR TITLE
Entry lv job chart

### DIFF
--- a/Frontend/src/components/Home.jsx
+++ b/Frontend/src/components/Home.jsx
@@ -8,6 +8,7 @@ import SummarySection from "./SummarySection";
 import SalaryHistogram from "./salaryhistogram";
 import AverageSalaryOverTimeChart from "./averagesalaryovertime";
 import DownloadCSVButton from "./downloadcsvbutton";
+import categoriseEntryLevelRole from "./utils/roleUtils";
 
 const Home = () => {
   const [skillsData, setSkillsData] = useState({
@@ -37,6 +38,8 @@ const Home = () => {
   const [locationChartType, setLocationChartType] = useState("bar");
   const [locationExpanded, setLocationExpanded] = useState(false);
   const [avgSalaryExpanded, setAvgSalaryExpanded] = useState(false);
+  const [rolesChartType, setRolesChartType] = useState("bar");
+  const [rolesExpanded, setRolesExpanded] = useState(false);
 
   const parseSalary = (job) => {
     const min = Number(job?.min_salary);
@@ -157,7 +160,9 @@ const Home = () => {
 
       const filteredGrouped = {};
       ALLOWED.forEach((k) => {
-        filteredGrouped[k] = (grouped[k] || []).sort((a, b) => b.count - a.count);
+        filteredGrouped[k] = (grouped[k] || []).sort(
+          (a, b) => b.count - a.count
+        );
       });
 
       setSkillsData(filteredGrouped);
@@ -251,6 +256,32 @@ const Home = () => {
     .filter(Boolean)
     .sort();
 
+  const getRolesData = () => {
+    const counts = {};
+    for (const job of filteredJobs) {
+      const bucket = categoriseEntryLevelRole(job);
+      if (!bucket) continue;
+      counts[bucket] = (counts[bucket] || 0) + 1;
+    }
+    const entries = Object.entries(counts)
+      .map(([name, value]) => ({ name, value }))
+      .sort((a, b) => b.value - a.value);
+    const sliced = rolesExpanded ? entries : entries.slice(0, 10);
+    return sliced.map(({ name, value }) => ({ skill: name, count: value }));
+  };
+
+  const renderRolesChart = () => {
+    const data = getRolesData();
+    return renderGenericCountChart(
+      "Entry-Level Roles",
+      data,
+      rolesChartType,
+      setRolesChartType,
+      rolesExpanded,
+      setRolesExpanded
+    );
+  };
+
   const renderSkillChart = (title, data, typeKey) => {
     const currentType = chartTypes[typeKey] || globalChartType;
     const isExpanded = expandedSections[typeKey] || false;
@@ -284,7 +315,9 @@ const Home = () => {
             <button
               key={type}
               onClick={() => setLocalChartType(type)}
-              className={`chart-type-btn ${currentType === type ? "active" : ""}`}
+              className={`chart-type-btn ${
+                currentType === type ? "active" : ""
+              }`}
             >
               {type.charAt(0).toUpperCase() + type.slice(1)}
             </button>
@@ -395,28 +428,23 @@ const Home = () => {
         </div>
       </div>
 
-      <div className="two-col">
-        {renderGenericCountChart(
-          "Top Hiring Companies",
-          jobCompanyData,
-          jobCompanyChartType,
-          setJobCompanyChartType,
-          jobCompanyExpanded,
-          setJobCompanyExpanded
-        )}
-        {renderGenericCountChart(
-          "Top Job Titles",
-          jobTitleData,
-          jobTitleChartType,
-          setJobTitleChartType,
-          jobTitleExpanded,
-          setJobTitleExpanded
-        )}
-      </div>
-
       <div className="section stacked-dashboard">
         {hasData && !errMsg && (
           <div style={{ width: "100%" }}>
+            {/* Row 2 — Entry-Level Roles | Top Job Titles */}
+            <div className="two-col full-width">
+              {renderRolesChart()}
+              {renderGenericCountChart(
+                "Top Job Titles",
+                jobTitleData,
+                jobTitleChartType,
+                setJobTitleChartType,
+                jobTitleExpanded,
+                setJobTitleExpanded
+              )}
+            </div>
+
+            {/* Row 3 — Job Heatmap | Average Salary per Scrape */}
             <div className="two-col full-width">
               <div className="chart-card heatmap-wrapper">
                 <h2 className="card-title">Job Heatmap</h2>
@@ -424,6 +452,7 @@ const Home = () => {
                   <LeafletHeatmap />
                 </div>
               </div>
+
               <div className="chart-card">
                 <h2 className="card-title">Average Salary per Scrape</h2>
                 <AverageSalaryOverTimeChart
@@ -435,7 +464,17 @@ const Home = () => {
               </div>
             </div>
 
+            {/* Row 4 — Top Hiring Companies | (paired with Job Locations) */}
             <div className="two-col full-width">
+              {renderGenericCountChart(
+                "Top Hiring Companies",
+                jobCompanyData,
+                jobCompanyChartType,
+                setJobCompanyChartType,
+                jobCompanyExpanded,
+                setJobCompanyExpanded
+              )}
+
               <div className="chart-card">
                 <h2 className="card-title">
                   <span>Job Locations</span>
@@ -463,14 +502,9 @@ const Home = () => {
                   layout="horizontal"
                 />
               </div>
-
-              {renderSkillChart(
-                "Soft skill",
-                skillsData["soft skill"] || [],
-                "soft skill"
-              )}
             </div>
 
+            {/* Remaining skill rows (pairs) */}
             {[
               "programming language",
               "framework",

--- a/Frontend/src/components/utils/roleUtils.jsx
+++ b/Frontend/src/components/utils/roleUtils.jsx
@@ -1,0 +1,63 @@
+// Normalises a raw job title into one of our entry-level role buckets.
+
+const BUCKETS = {
+  'Software Developer': [
+    'software developer','software engineer','full stack','backend','.net','java developer',
+    'python developer','node developer','typescript developer','react developer (full stack)',
+    'graduate developer','junior developer','grad software','junior software'
+  ],
+  'Web / Front-end Developer': [
+    'front end','frontend','web developer','ui developer','javascript developer (front)',
+    'react developer','angular developer','vue developer','html','css'
+  ],
+  'QA / Tester / Test Analyst': [
+    'qa','quality assurance','tester','test analyst','automation tester','manual tester','software tester'
+  ],
+  'IT Support / Service Desk': [
+    'it support','service desk','helpdesk','help desk','desktop support','support analyst'
+  ],
+  'Systems Admin / DevOps (Junior)': [
+    'systems administrator','sysadmin','linux admin','windows admin','devops','site reliability','sre',
+    'infrastructure engineer','platform engineer'
+  ],
+  'Data Analyst / BI': [
+    'data analyst','business intelligence','bi analyst','power bi','tableau','insights analyst','reporting analyst'
+  ],
+  'Database (DBA) / ETL': [
+    'dba','database administrator','etl','data engineer (junior)','ssis','ssrs'
+  ],
+  'Cybersecurity / SOC': [
+    'cyber','security analyst','soc analyst','siem','vulnerability','secops'
+  ],
+  'Business Analyst': [
+    'business analyst','ba','requirements analyst'
+  ],
+  'Game Dev / Technical Artist': [
+    'game developer','unity','unreal','technical artist','game programmer'
+  ],
+};
+
+const TITLE_FIELDS = ['title','job_title','position','role','name'];
+
+export function categoriseEntryLevelRole(job = {}) {
+  let rawTitle = '';
+  for (const f of TITLE_FIELDS) {
+    if (typeof job[f] === 'string' && job[f].trim()) { rawTitle = job[f]; break; }
+  }
+  if (!rawTitle) return null;
+
+  const title = rawTitle.toLowerCase();
+  const isGradOrJunior = /\b(junior|graduate|grad|entry|trainee)\b/.test(title);
+
+  for (const [bucket, keywords] of Object.entries(BUCKETS)) {
+    for (const k of keywords) {
+      if (title.includes(k)) return bucket;
+    }
+  }
+  if (isGradOrJunior && /\b(dev|engineer|developer|programmer)\b/.test(title)) {
+    return 'Software Developer';
+  }
+  return null;
+}
+
+export default categoriseEntryLevelRole;


### PR DESCRIPTION
# Add Entry-Level Roles chart and reorganize dashboard layout

## Summary
This PR introduces a new **Entry-Level Roles** visualization and reorganizes the dashboard layout to improve clarity and consistency. The Roles chart buckets common graduate/entry positions (e.g., Junior Software Developer, QA Tester, IT Support) from the existing jobs feed and renders them using the same generic chart component used elsewhere for a consistent header, CSV export, and chart-type toggles.

## Key Changes
- Add roles bucketing via `categoriseEntryLevelRole(job)` and `getRolesData()` in `Home.jsx`.
- Render Roles using the shared `renderGenericCountChart` to align styling and controls.
- Reorganize the dashboard to the requested layout:
  1) Jobs Posted Over Time | Salary Distribution  
  2) Entry-Level Roles | Top Job Titles  
  3) Job Heatmap | Average Salary per Scrape  
  4) Top Hiring Companies | Job Locations  
  5) Remaining skills in pairs (Soft skill; Programming language | Framework; Tool | Platform; Methodology | Database)
- Remove the earlier mixed row that rendered Top Hiring Companies next to Top Job Titles, which caused a duplicate Titles chart and layout gaps.
- Minor CSV label polish so Roles exports with the header “Role”.

## Files Touched
- `frontend/src/components/Home.jsx`
  - Added: `getRolesData()` helper, `renderRolesChart()` wrapper.
  - Replaced: roles rendering to use `renderGenericCountChart`.
  - Reordered JSX blocks to match the target layout.
  - Removed the duplicate early block that rendered Top Hiring Companies and Top Job Titles in the same row.
- `frontend/src/components/utils/roleUtils.jsx` (already present)
  - Provides `categoriseEntryLevelRole(job)` used by `Home.jsx`.
